### PR TITLE
EDE-996 Make code compatible to s3 buckets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,11 +17,11 @@ This XBlock is not compatible with its `ancestor <https://github.com/raccoongang
 Installation
 ------------
 
-This XBlock was designed to work out of the box with `Tutor <https://docs.tutor.overhang.io>`__ (Ironwood release). It comes bundled by default in the official Tutor releases, such that there is no need to install it manually.
+This XBlock was designed to work out of the box with `Tutor <https://docs.tutor.overhang.io>`__ (Ironwood release). But in this fork it has been made compatible with juniper release. It comes bundled by default in the official Tutor releases, such that there is no need to install it manually.
 
-For non-Tutor platforms, you should install the `Python package from Pypi <https://pypi.org/project/openedx-scorm-xblock/>`__::
+For non-Tutor platforms, you can install it using following command::
 
-    pip install openedx-scorm-xblock
+    pip install git+https://github.com/edly-io/openedx-scorm-xblock.git@master#egg=openedx-scorm-xblock
 
 Usage
 -----
@@ -45,6 +45,29 @@ Development
 Run unit tests with::
 
     $ NO_PREREQ_INSTALL=1 paver test_system -s lms -t openedxscorm
+Nginx settings (for non-local environments) if you are using s3-buckets
+------
+In `/etc/nginx/sites-enabled/lms` and `/etc/nginx/sites-enabled/cms` put these rules
+```
+location /scorm/ {
+    rewrite ^/scorm/(.*) /$1 break;
+    try_files $uri @s3;
+  }
+location @s3 {
+    proxy_pass <YOUR S3 BUCKET BASE PATH>;
+  }
+```
+**For exmaple** Your s3 bucket base path can be
+https://c90081bas2001edx.s3.amazonaws.com
+We are doing this because in openedx, we will retrieve content from s3-bucket and display it in an iframe. But because of x-frame-options restrictions we will be blocked. So, to overcome that hurdle we have just replaced the base s3-bucket url with our platform base url in our xblock. Let's understand it from an exmaple. Let's say one of your url for scorm asset available on s3-bucket is
+[https://c90081bas2001edx.s3.amazonaws.com/scorm/503a49b7ed1d4a2caa22af84df87fa8c/f792c4c021da74aac780e072bf16aa0ed4987767/shared/launchpage.html](https://c90081bas2001edx.s3.amazonaws.com/scorm/503a49b7ed1d4a2caa22af84df87fa8c/f792c4c021da74aac780e072bf16aa0ed4987767/shared/launchpage.html)
+But openedx will be unable to open it in an iframe. So what we have done is that we have replaced the base url of this url with the base url of openedx so the source url for the iframe will be
+[https://dev.learn.clearesult.com/scorm/503a49b7ed1d4a2caa22af84df87fa8c/f792c4c021da74aac780e072bf16aa0ed4987767/shared/launchpage.html](https://dev.learn.clearesult.com/scorm/503a49b7ed1d4a2caa22af84df87fa8c/f792c4c021da74aac780e072bf16aa0ed4987767/shared/launchpage.html)
+In this way we overcome the x-frame-options restrictions. Now the other problem is that our scorm asset is not available on this url. It is available on s3-bucket. This is where the nginx rules come handy. When any hit will be made for
+[https://dev.learn.clearesult.com/scorm/503a49b7ed1d4a2caa22af84df87fa8c/f792c4c021da74aac780e072bf16aa0ed4987767/shared/launchpage.html](https://dev.learn.clearesult.com/scorm/503a49b7ed1d4a2caa22af84df87fa8c/f792c4c021da74aac780e072bf16aa0ed4987767/shared/launchpage.html)
+It will go to nginx where we have already written a rule that for all those requests whose urls start with `/scorm/`, we will replace the base url with s3-bucket base-url. So, in this way the final request will be made to the actual url i.e.
+https://c90081bas2001edx.s3.amazonaws.com/scorm/503a49b7ed1d4a2caa22af84df87fa8c/f792c4c021da74aac780e072bf16aa0ed4987767/shared/launchpage.html
+
 
 License
 -------


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/EDE-996](https://edlyio.atlassian.net/browse/EDE-996)

**Description**
The previous version of this xblock is not compatible when we use s3-buckets as our file storage. In the codebase, there are two blocks

**Number1**
```
        default_storage.save(self.package_path, File(package_file))
        logger.info('Scorm "%s" file stored at "%s"', package_file, self.package_path)
```
**Number2**
```
       with zipfile.ZipFile(package_file, "r") as scorm_zipfile:
            for zipinfo in scorm_zipfile.infolist():
                # Do not unzip folders, only files. In Python 3.6 we will have access to
                # the is_dir() method to verify whether a ZipInfo object points to a
                # directory.
                # https://docs.python.org/3.6/library/zipfile.html#zipfile.ZipInfo.is_dir
                if not zipinfo.filename.endswith("/"):
                    default_storage.save(
                        os.path.join(self.extract_folder_path, zipinfo.filename),
                        BytesIO(scorm_zipfile.open(zipinfo.filename).read()),
                    )
```

The Number1 code block will be executed earlier than the Number2 code block. Number1 does some processing on the uploaded `package_file` and then it closes the file and flushes it.
Because of which, Number2 block couldn't get the `package_file`

This thing has been fixed in this PR. Now, we are creating a temporary file and using that file in our Number2 block.