### PR TITLE
Scorm XBlock handle to serve SCORM content from a private S3 bucket

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,9 @@ By default, SCORM modules will be accessible at "/scorm/" urls and static assets
         "SCORM_FILE_STORAGE_TYPE": "openedx.features.clearesult_features.backend_storage.ScormXblockS3Storage"
     }
 
+Here ``SCORM_FILE_STORAGE_TYPE`` shows that we are using our own custom storage backend. You can get the idea from
+`Philanthropy Storage Backend <https://github.com/philanthropy-u/edx-platform/blob/master/openedx/features/philu_utils/backend_storage.py>`_
+
 If you are using this xblock locally, there is a configuration variable whose value you will have to set empty string::
 
     XBLOCK_SETTINGS["ScormXBlock"] = {

--- a/README.rst
+++ b/README.rst
@@ -17,11 +17,11 @@ This XBlock is not compatible with its `ancestor <https://github.com/raccoongang
 Installation
 ------------
 
-This XBlock was designed to work out of the box with `Tutor <https://docs.tutor.overhang.io>`__ (Ironwood release). It comes bundled by default in the official Tutor releases, such that there is no need to install it manually.
+This XBlock was designed to work out of the box with `Tutor <https://docs.tutor.overhang.io>`__ (Ironwood release). But in this fork it has been made compatible with juniper release. It comes bundled by default in the official Tutor releases, such that there is no need to install it manually.
 
-For non-Tutor platforms, you should install the `Python package from Pypi <https://pypi.org/project/openedx-scorm-xblock/>`__::
+For non-Tutor platforms, you can install it using following command::
 
-    pip install openedx-scorm-xblock
+    pip install git+https://github.com/edly-io/openedx-scorm-xblock.git@master#egg=openedx-scorm-xblock
 
 Usage
 -----
@@ -37,7 +37,18 @@ By default, SCORM modules will be accessible at "/scorm/" urls and static assets
 
     XBLOCK_SETTINGS["ScormXBlock"] = {
         "LOCATION": "alternatevalue",
+        "SCORM_FILE_STORAGE_TYPE": "openedx.features.clearesult_features.backend_storage.ScormXblockS3Storage"
     }
+
+If you are using this xblock locally, there is a configuration variable whose value you will have to set empty string::
+
+    XBLOCK_SETTINGS["ScormXBlock"] = {
+        "SCORM_MEDIA_BASE_URL": ""
+    }
+
+You can face x-frame-options restrictions. For that, you can use any workaround. Like for local you can install any extension on chrome which will disable x-frame-restrictions.
+For example: `Ignore X-Frame headers <https://chrome.google.com/webstore/detail/ignore-x-frame-headers/gleekbfjekiniecknbkamfmkohkpodhe>`_ Google Chrome extension.
+
 
 Development
 -----------
@@ -45,6 +56,29 @@ Development
 Run unit tests with::
 
     $ NO_PREREQ_INSTALL=1 paver test_system -s lms -t openedxscorm
+Nginx settings (for non-local environments) if you are using s3-buckets
+------
+In ``/etc/nginx/sites-enabled/lms`` and ``/etc/nginx/sites-enabled/cms`` put these rules::
+
+    location /scorm/ {
+        rewrite ^/scorm/(.*) /$1 break;
+        try_files $uri @s3;
+      }
+    location @s3 {
+        proxy_pass <YOUR S3 BUCKET BASE PATH>;
+      }
+
+**For exmaple** Your s3 bucket base path can be
+https://c90081bas2001edx.s3.amazonaws.com
+We are doing this because in openedx, we will retrieve content from s3-bucket and display it in an iframe. But because of x-frame-options restrictions we will be blocked. So, to overcome that hurdle we have just replaced the base s3-bucket url with our platform base url in our xblock. Let's understand it from an exmaple. Let's say one of your url for scorm asset available on s3-bucket is
+https://c90081bas2001edx.s3.amazonaws.com/scorm/503a49b7ed1d4a2caa22af84df87fa8c/f792c4c021da74aac780e072bf16aa0ed4987767/shared/launchpage.html
+But openedx will be unable to open it in an iframe. So what we have done is that we have replaced the base url of this url with the base url of openedx so the source url for the iframe will be
+https://dev.learn.clearesult.com/scorm/503a49b7ed1d4a2caa22af84df87fa8c/f792c4c021da74aac780e072bf16aa0ed4987767/shared/launchpage.html
+In this way we overcome the x-frame-options restrictions. Now the other problem is that our scorm asset is not available on this url. It is available on s3-bucket. This is where the nginx rules come handy. When any hit will be made for
+https://dev.learn.clearesult.com/scorm/503a49b7ed1d4a2caa22af84df87fa8c/f792c4c021da74aac780e072bf16aa0ed4987767/shared/launchpage.html
+It will go to nginx where we have already written a rule that for all those requests whose urls start with `/scorm/`, we will replace the base url with s3-bucket base-url. So, in this way the final request will be made to the actual url i.e.
+https://c90081bas2001edx.s3.amazonaws.com/scorm/503a49b7ed1d4a2caa22af84df87fa8c/f792c4c021da74aac780e072bf16aa0ed4987767/shared/launchpage.html
+
 
 License
 -------

--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -11,6 +11,7 @@ import xml.etree.ElementTree as ET
 import zipfile
 import concurrent.futures
 
+from completion import waffle as completion_waffle
 from django.conf import settings
 from django.core.files import File
 from django.template import Context, Template
@@ -19,6 +20,7 @@ from webob import Response
 import pkg_resources
 
 from web_fragments.fragment import Fragment
+from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
 from xblock.fields import Scope, String, Float, Boolean, Dict, DateTime, Integer
 
@@ -56,6 +58,8 @@ class ScormXBlock(XBlock):
     Note that neither the folder the folder nor the package file are deleted when the
     xblock is removed.
     """
+    has_custom_completion = True
+    completion_mode = XBlockCompletionMode.COMPLETABLE
 
     display_name = String(
         display_name=_("Display Name"),
@@ -331,6 +335,35 @@ class ScormXBlock(XBlock):
         self.runtime.publish(
             self, "grade", {"value": self.get_grade(), "max_value": self.weight},
         )
+        self.publish_completion()
+
+
+    def publish_completion(self):
+        """
+        Mark scorm xbloxk as completed if user has completed the scorm course unit.
+
+        it will work along with the edX completion tool: https://github.com/edx/completion
+        """
+        if not completion_waffle.waffle().is_enabled(completion_waffle.ENABLE_COMPLETION_TRACKING):
+            return
+
+        if XBlockCompletionMode.get_mode(self) != XBlockCompletionMode.COMPLETABLE:
+            return
+
+        completion_value = 0.0
+        if not self.has_score:
+            # component does not have any score
+            if self.get_completion_status() == "completed":
+                completion_value = 1.0
+        else:
+            if self.get_completion_status() in ["passed", "failed"]:
+                completion_value = 1.0
+
+        data = {
+            "completion": completion_value
+        }
+        self.runtime.publish(self, "completion", data)
+
 
     def get_grade(self):
         lesson_score = self.lesson_score

--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -1,4 +1,3 @@
-from functools import partial
 from urllib.parse import urlparse
 import importlib
 import json
@@ -10,9 +9,12 @@ import re
 import xml.etree.ElementTree as ET
 import zipfile
 import concurrent.futures
+import requests
+import mimetypes
+import boto3
 
-from completion import waffle as completion_waffle
 from django.conf import settings
+from completion import waffle as completion_waffle
 from django.core.files import File
 from django.template import Context, Template
 from django.utils import timezone
@@ -173,6 +175,70 @@ class ScormXBlock(XBlock):
         )
 
     @XBlock.handler
+    def scorm_view(self, request, _suffix):
+        """
+        View for serving SCORM content. It receives a request with the path to the SCORM content to serve, generates a pre-signed
+        URL to access the content in the AWS S3 bucket, retrieves the file content and returns it with the appropriate content
+        type.
+
+        Parameters:
+        ----------
+        request : django.http.request.HttpRequest
+            HTTP request object containing the path to the SCORM content to serve.
+        _suffix : str
+            Unused parameter.
+
+        Returns:
+        -------
+        Response object containing the content of the requested file with the appropriate content type.
+        """
+        path = request.url.split('scorm_view/')[-1]
+        path = re.sub(r"(\?.*|:[\d:]*$)", "", path)
+        file_name = os.path.basename(path)
+        signed_url = self.get_presigned_url(path)
+        if not signed_url:
+            return signed_url
+
+        file_content = requests.get(signed_url).content
+        file_type, _ = mimetypes.guess_type(file_name)
+
+        return Response(
+            file_content, content_type=file_type
+        )
+
+        
+    def get_presigned_url(self, file_path):
+        """
+        Generates a pre-signed URL to access a file in an AWS S3 bucket.
+
+        Parameters:
+        ----------
+        file_path : str
+            The path to the file to access in the S3 bucket.
+
+        Returns:
+        -------
+        str
+            The pre-signed URL for accessing the file.
+        """
+        presigned_url = ""
+        if self.storage.exists(os.path.join(self.extract_folder_path, 
+                                            file_path)):
+            expires_in = 86400
+            # Get a boto3 client instance for S3
+            s3_client = boto3.client('s3',
+                                    aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+                                    aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+                                    region_name=settings.AWS_S3_REGION_NAME)
+            # Generate the presigned URL
+            presigned_url = s3_client.generate_presigned_url('get_object',
+                                                            Params={'Bucket': settings.AWS_STORAGE_BUCKET_NAME,
+                                                                    'Key': os.path.join(self.extract_folder_path, file_path)},
+                                                            ExpiresIn=expires_in)
+            
+        return presigned_url
+    
+    @XBlock.handler
     def studio_submit(self, request, _suffix):
         self.display_name = request.params["display_name"]
         self.width = request.params["width"]
@@ -246,19 +312,7 @@ class ScormXBlock(XBlock):
     def index_page_url(self):
         if not self.package_meta or not self.index_page_path:
             return ""
-        folder = self.extract_folder_path
-        if scorm_storage_instance.exists(
-            os.path.join(self.extract_folder_base_path, self.index_page_path)
-        ):
-            # For backward-compatibility, we must handle the case when the xblock data
-            # is stored in the base folder.
-            folder = self.extract_folder_base_path
-            logger.warning("Serving SCORM content from old-style path: %s", folder)
-        url = scorm_storage_instance.url(os.path.join(folder, self.index_page_path))
-        if SCORM_MEDIA_BASE_URL:
-            splitted_url = list(urlparse(url))
-            url = "{base_url}{path}".format(base_url=SCORM_MEDIA_BASE_URL, path=splitted_url[2])
-
+        url = settings.CMS_BASE + "/xblock/" + str(self.scope_ids.usage_id) + "/handler/scorm_view/" + self.index_page_path
         return url
 
     @property


### PR DESCRIPTION
Create the scorm_view function to serve SCORM content from a private S3 bucket using pre-signed URLs

Previously, the scorm_view function in the XBlock handler accessed files directly from the S3 bucket without any authentication, which posed a security risk. To address this issue, we updated the function to use the get_presigned_url function, which generates a pre-signed URL for accessing the file in the private S3 bucket. We then used this pre-signed URL to retrieve the file content and return it with the appropriate content type.

This update ensures that SCORM content is served securely from a private S3 bucket using pre-signed URLs, improving the overall security of the XBlock handler.
